### PR TITLE
Use 1 task that calls 2 jobs

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,11 +1,8 @@
 desc "Send reminders to renew requests confirmation"
-task proc_reminders: :environment do
+task daily_procs: :environment do
   puts "Send confirmation renewal reminders..."
   RemindersJob.perform_now
-end
 
-desc "Automatically close unconfirmed requests"
-task proc_expired: :environment do
   puts "Close unconfirmed requests..."
   ExpiredJob.perform_now
 end


### PR DESCRIPTION
Group the 2 jobs in a same task to avoid forgotten task in Heroku Scheduler